### PR TITLE
Santa Clara City Of - 236

### DIFF
--- a/full_utility_rates/California/Santa Clara City Of - 236/SCCO-2017-01-01.owrs
+++ b/full_utility_rates/California/Santa Clara City Of - 236/SCCO-2017-01-01.owrs
@@ -9,7 +9,7 @@ rate_structure:
     service_charge:
       depends_on: meter_size
       values:
-        5/8*3/4": 19.98
+        5/8"    : 19.98
         3/4"    : 25.26
         1"      : 35.80
         1 1/2"  : 62.16
@@ -34,7 +34,7 @@ rate_structure:
     service_charge:
       depends_on: meter_size
       values:
-        5/8*3/4": 19.98
+        5/8"    : 19.98
         3/4"    : 25.26
         1"      : 35.80
         1 1/2"  : 62.16
@@ -52,7 +52,7 @@ rate_structure:
     service_charge:
       depends_on: meter_size
       values:
-        5/8*3/4": 19.98
+        5/8"    : 19.98
         3/4"    : 25.26
         1"      : 35.80
         1 1/2"  : 62.16
@@ -70,7 +70,7 @@ rate_structure:
     service_charge:
       depends_on: meter_size
       values:
-        5/8*3/4": 19.98
+        5/8"    : 19.98
         3/4"    : 25.26
         1"      : 35.80
         1 1/2"  : 62.16

--- a/full_utility_rates/California/Santa Clara City Of - 236/SCCO-2017-01-01.owrs
+++ b/full_utility_rates/California/Santa Clara City Of - 236/SCCO-2017-01-01.owrs
@@ -1,0 +1,85 @@
+---
+metadata:
+  effective_date: 2017-01-01
+  utility_name: "Santa Clarita Water Division"
+  bill_frequency: monthly
+
+rate_structure:
+  RESIDENTIAL_SINGLE:
+    service_charge:
+      depends_on: meter_size
+      values:
+        5/8*3/4": 19.98
+        3/4"    : 25.26
+        1"      : 35.80
+        1 1/2"  : 62.16
+        2"      : 93.80
+        3"      : 178.18
+        4       : 273.11
+        6       : 536.79
+        8       : 853.19
+        10      : 1222.35
+    budget: Tiered
+    tier_starts:
+      - 0
+      - 15
+      - 50
+    tier_prices:
+      - 1.8015
+      - 2.0094
+      - 2.6417
+    commodity_charge: budget
+
+  IRRIGATION:
+    service_charge:
+      depends_on: meter_size
+      values:
+        5/8*3/4": 19.98
+        3/4"    : 25.26
+        1"      : 35.80
+        1 1/2"  : 62.16
+        2"      : 93.80
+        3"      : 178.18
+        4       : 273.11
+        6       : 536.79
+        8       : 853.19
+        10      : 1222.35
+    flat_rate: 2.6417
+    commodity_charge: flat_rate*usage_ccf
+    bill: commodity_charge+service_charge
+
+  OTHER:
+    service_charge:
+      depends_on: meter_size
+      values:
+        5/8*3/4": 19.98
+        3/4"    : 25.26
+        1"      : 35.80
+        1 1/2"  : 62.16
+        2"      : 93.80
+        3"      : 178.18
+        4       : 273.11
+        6       : 536.79
+        8       : 853.19
+        10      : 1222.35
+    flat_rate: 2.0094
+    commodity_charge: flat_rate*usage_ccf
+    bill: commodity_charge+service_charge
+
+  FIRE_SERVICE:
+    service_charge:
+      depends_on: meter_size
+      values:
+        5/8*3/4": 19.98
+        3/4"    : 25.26
+        1"      : 35.80
+        1 1/2"  : 62.16
+        2"      : 93.80
+        3"      : 178.18
+        4       : 273.11
+        6       : 536.79
+        8       : 853.19
+        10      : 1222.35
+   flat_rate: 2.84
+   commodity_charge: flat_rate*meter_size
+   bill: commodity_charge+service_charge


### PR DESCRIPTION
**Comment #1:**
In this code - there is a "Consumer_Class" called "OTHERS" which contains everything from Residential_Multi_Family to Other classes - the reason for this is that there has not been a clear distinction for the other classes in the site's water rate reports. 

**Comment #2:**
For the "FIRE_SERVICE" class, the website says that the calculation will be per diameter inch with the flat_rate - since I couldn't make out what that meant - I used the meter_values itself to be multiplied with the flat_rate - this might be helpful to check out whenever needed.

**Varun and Vipassana were at loss here for these same issues**