### PR TITLE
West sacramento city of

### DIFF
--- a/full_utility_rates/California/West Sacramento  City Of - 3167/07-01-2017.owrs
+++ b/full_utility_rates/California/West Sacramento  City Of - 3167/07-01-2017.owrs
@@ -1,0 +1,75 @@
+metadata:
+  effective_date: 07/01/2017
+  utility_name: West Sacramento  City Of
+  bill_frequency: Monthly
+  bill_unit: ccf
+rate_structure:
+  RESIDENTIAL_SINGLE:
+    service_charge:
+      depends_on:
+        - meter_size
+      values:
+        5/8": 18.02
+        3/4": 18.02
+        1": 30
+        1|1/2": 59.87
+        2": 95.91
+        3": 191.9
+        4": 299.85
+        6": 599.5
+        8": 959.3
+        10": 1378.91
+        12": 2023.63
+    commodity_charge: flat_rate_commodity*usage_ccf
+    flat_rate_commodity: 2.13
+    fixed_drought_surcharge: 0
+    variable_drought_surcharge: 0
+    fixed_wastewater_charge: 0
+    variable_wastewater_charge: 0
+    bill: service_charge+commodity_charge
+  RESIDENTIAL_MULTI:
+    service_charge:
+      depends_on:
+        - meter_size
+      values:
+        5/8": 18.02
+        3/4": 18.02
+        1": 30
+        1|1/2": 59.87
+        2": 95.91
+        3": 191.9
+        4": 299.85
+        6": 599.5
+        8": 959.3
+        10": 1378.91
+        12": 2023.63
+    commodity_charge: flat_rate_commodity*usage_ccf
+    flat_rate_commodity: 2.13
+    fixed_drought_surcharge: 0
+    variable_drought_surcharge: 0
+    fixed_wastewater_charge: 0
+    variable_wastewater_charge: 0
+    bill: service_charge+commodity_charge
+  NON_RESIDENTIAL:
+    service_charge:
+      depends_on:
+        - meter_size
+      values:
+        5/8": 18.02
+        3/4": 18.02
+        1": 30
+        1|1/2": 59.87
+        2": 95.91
+        3": 191.9
+        4": 299.85
+        6": 599.5
+        8": 959.3
+        10": 1378.91
+        12": 2023.63
+    commodity_charge: flat_rate_commodity*usage_ccf
+    flat_rate_commodity: 2.13
+    fixed_drought_surcharge: 0
+    variable_drought_surcharge: 0
+    fixed_wastewater_charge: 0
+    variable_wastewater_charge: 0
+    bill: service_charge+commodity_charge

--- a/full_utility_rates/California/West Sacramento  City Of - 3167/07-01-2017.owrs
+++ b/full_utility_rates/California/West Sacramento  City Of - 3167/07-01-2017.owrs
@@ -73,3 +73,72 @@ rate_structure:
     fixed_wastewater_charge: 0
     variable_wastewater_charge: 0
     bill: service_charge+commodity_charge
+  IRRIGATION:
+    service_charge:
+      depends_on:
+        - meter_size
+      values:
+        5/8": 18.02
+        3/4": 18.02
+        1": 30
+        1|1/2": 59.87
+        2": 95.91
+        3": 191.9
+        4": 299.85
+        6": 599.5
+        8": 959.3
+        10": 1378.91
+        12": 2023.63
+    commodity_charge: flat_rate_commodity*usage_ccf
+    flat_rate_commodity: 2.13
+    fixed_drought_surcharge: 0
+    variable_drought_surcharge: 0
+    fixed_wastewater_charge: 0
+    variable_wastewater_charge: 0
+    bill: service_charge+commodity_charge
+  COMMERCIAL:
+    service_charge:
+      depends_on:
+        - meter_size
+      values:
+        5/8": 18.02
+        3/4": 18.02
+        1": 30
+        1|1/2": 59.87
+        2": 95.91
+        3": 191.9
+        4": 299.85
+        6": 599.5
+        8": 959.3
+        10": 1378.91
+        12": 2023.63
+    commodity_charge: flat_rate_commodity*usage_ccf
+    flat_rate_commodity: 2.13
+    fixed_drought_surcharge: 0
+    variable_drought_surcharge: 0
+    fixed_wastewater_charge: 0
+    variable_wastewater_charge: 0
+    bill: service_charge+commodity_charge
+  INDUSTRIAL:
+    service_charge:
+      depends_on:
+        - meter_size
+      values:
+        5/8": 18.02
+        3/4": 18.02
+        1": 30
+        1|1/2": 59.87
+        2": 95.91
+        3": 191.9
+        4": 299.85
+        6": 599.5
+        8": 959.3
+        10": 1378.91
+        12": 2023.63
+    commodity_charge: flat_rate_commodity*usage_ccf
+    flat_rate_commodity: 2.13
+    fixed_drought_surcharge: 0
+    variable_drought_surcharge: 0
+    fixed_wastewater_charge: 0
+    variable_wastewater_charge: 0
+    bill: service_charge+commodity_charge

--- a/full_utility_rates/California/West Sacramento  City Of - 3167/07-01-2018.owrs
+++ b/full_utility_rates/California/West Sacramento  City Of - 3167/07-01-2018.owrs
@@ -1,0 +1,75 @@
+metadata:
+  effective_date: 07/01/2018
+  utility_name: West Sacramento  City Of
+  bill_frequency: Monthly
+  bill_unit: ccf
+rate_structure:
+  RESIDENTIAL_SINGLE:
+    service_charge:
+      depends_on:
+        - meter_size
+      values:
+        5/8": 23.42
+        3/4": 23.42
+        1": 39
+        1|1/2": 77.83
+        2": 124.69
+        3": 249.46
+        4": 389.81
+        6": 779.35
+        8": 1247.09
+        10": 1792.58
+        12": 2630.72
+    commodity_charge: flat_rate_commodity*usage_ccf
+    flat_rate_commodity: 2.3
+    fixed_drought_surcharge: 0
+    variable_drought_surcharge: 0
+    fixed_wastewater_charge: 0
+    variable_wastewater_charge: 0
+    bill: service_charge+commodity_charge
+  RESIDENTIAL_MULTI:
+    service_charge:
+      depends_on:
+        - meter_size
+      values:
+        5/8": 23.42
+        3/4": 23.42
+        1": 39
+        1|1/2": 77.83
+        2": 124.69
+        3": 249.46
+        4": 389.81
+        6": 779.35
+        8": 1247.09
+        10": 1792.58
+        12": 2630.72
+    commodity_charge: flat_rate_commodity*usage_ccf
+    flat_rate_commodity: 2.3
+    fixed_drought_surcharge: 0
+    variable_drought_surcharge: 0
+    fixed_wastewater_charge: 0
+    variable_wastewater_charge: 0
+    bill: service_charge+commodity_charge
+  NON_RESIDENTIAL:
+    service_charge:
+      depends_on:
+        - meter_size
+      values:
+        5/8": 23.42
+        3/4": 23.42
+        1": 39
+        1|1/2": 77.83
+        2": 124.69
+        3": 249.46
+        4": 389.81
+        6": 779.35
+        8": 1247.09
+        10": 1792.58
+        12": 2630.72
+    commodity_charge: flat_rate_commodity*usage_ccf
+    flat_rate_commodity: 2.3
+    fixed_drought_surcharge: 0
+    variable_drought_surcharge: 0
+    fixed_wastewater_charge: 0
+    variable_wastewater_charge: 0
+    bill: service_charge+commodity_charge

--- a/full_utility_rates/California/West Sacramento  City Of - 3167/07-01-2018.owrs
+++ b/full_utility_rates/California/West Sacramento  City Of - 3167/07-01-2018.owrs
@@ -73,3 +73,72 @@ rate_structure:
     fixed_wastewater_charge: 0
     variable_wastewater_charge: 0
     bill: service_charge+commodity_charge
+  IRRIGATION:
+    service_charge:
+      depends_on:
+        - meter_size
+      values:
+        5/8": 23.42
+        3/4": 23.42
+        1": 39
+        1|1/2": 77.83
+        2": 124.69
+        3": 249.46
+        4": 389.81
+        6": 779.35
+        8": 1247.09
+        10": 1792.58
+        12": 2630.72
+    commodity_charge: flat_rate_commodity*usage_ccf
+    flat_rate_commodity: 2.3
+    fixed_drought_surcharge: 0
+    variable_drought_surcharge: 0
+    fixed_wastewater_charge: 0
+    variable_wastewater_charge: 0
+    bill: service_charge+commodity_charge
+  COMMERCIAL:
+    service_charge:
+      depends_on:
+        - meter_size
+      values:
+        5/8": 23.42
+        3/4": 23.42
+        1": 39
+        1|1/2": 77.83
+        2": 124.69
+        3": 249.46
+        4": 389.81
+        6": 779.35
+        8": 1247.09
+        10": 1792.58
+        12": 2630.72
+    commodity_charge: flat_rate_commodity*usage_ccf
+    flat_rate_commodity: 2.3
+    fixed_drought_surcharge: 0
+    variable_drought_surcharge: 0
+    fixed_wastewater_charge: 0
+    variable_wastewater_charge: 0
+    bill: service_charge+commodity_charge
+  INDUSTRIAL:
+    service_charge:
+      depends_on:
+        - meter_size
+      values:
+        5/8": 23.42
+        3/4": 23.42
+        1": 39
+        1|1/2": 77.83
+        2": 124.69
+        3": 249.46
+        4": 389.81
+        6": 779.35
+        8": 1247.09
+        10": 1792.58
+        12": 2630.72
+    commodity_charge: flat_rate_commodity*usage_ccf
+    flat_rate_commodity: 2.3
+    fixed_drought_surcharge: 0
+    variable_drought_surcharge: 0
+    fixed_wastewater_charge: 0
+    variable_wastewater_charge: 0
+    bill: service_charge+commodity_charge

--- a/full_utility_rates/California/West Sacramento  City Of - 3167/07-01-2019.owrs
+++ b/full_utility_rates/California/West Sacramento  City Of - 3167/07-01-2019.owrs
@@ -73,3 +73,72 @@ rate_structure:
     fixed_wastewater_charge: 0
     variable_wastewater_charge: 0
     bill: service_charge+commodity_charge
+  IRRIGATION:
+    service_charge:
+      depends_on:
+        - meter_size
+      values:
+        5/8": 23.89
+        3/4": 23.89
+        1": 39.78
+        1|1/2": 79.39
+        2": 127.18
+        3": 254.45
+        4": 397.61
+        6": 794.94
+        8": 1272.03
+        10": 1828.43
+        12": 2683.33
+    commodity_charge: flat_rate_commodity*usage_ccf
+    flat_rate_commodity: 2.35
+    fixed_drought_surcharge: 0
+    variable_drought_surcharge: 0
+    fixed_wastewater_charge: 0
+    variable_wastewater_charge: 0
+    bill: service_charge+commodity_charge
+  COMMERCIAL:
+    service_charge:
+      depends_on:
+        - meter_size
+      values:
+        5/8": 23.89
+        3/4": 23.89
+        1": 39.78
+        1|1/2": 79.39
+        2": 127.18
+        3": 254.45
+        4": 397.61
+        6": 794.94
+        8": 1272.03
+        10": 1828.43
+        12": 2683.33
+    commodity_charge: flat_rate_commodity*usage_ccf
+    flat_rate_commodity: 2.35
+    fixed_drought_surcharge: 0
+    variable_drought_surcharge: 0
+    fixed_wastewater_charge: 0
+    variable_wastewater_charge: 0
+    bill: service_charge+commodity_charge
+  INDUSTRIAL:
+    service_charge:
+      depends_on:
+        - meter_size
+      values:
+        5/8": 23.89
+        3/4": 23.89
+        1": 39.78
+        1|1/2": 79.39
+        2": 127.18
+        3": 254.45
+        4": 397.61
+        6": 794.94
+        8": 1272.03
+        10": 1828.43
+        12": 2683.33
+    commodity_charge: flat_rate_commodity*usage_ccf
+    flat_rate_commodity: 2.35
+    fixed_drought_surcharge: 0
+    variable_drought_surcharge: 0
+    fixed_wastewater_charge: 0
+    variable_wastewater_charge: 0
+    bill: service_charge+commodity_charge

--- a/full_utility_rates/California/West Sacramento  City Of - 3167/07-01-2019.owrs
+++ b/full_utility_rates/California/West Sacramento  City Of - 3167/07-01-2019.owrs
@@ -1,0 +1,75 @@
+metadata:
+  effective_date: 07/01/2019
+  utility_name: West Sacramento  City Of
+  bill_frequency: Monthly
+  bill_unit: ccf
+rate_structure:
+  RESIDENTIAL_SINGLE:
+    service_charge:
+      depends_on:
+        - meter_size
+      values:
+        5/8": 23.89
+        3/4": 23.89
+        1": 39.78
+        1|1/2": 79.39
+        2": 127.18
+        3": 254.45
+        4": 397.61
+        6": 794.94
+        8": 1272.03
+        10": 1828.43
+        12": 2683.33
+    commodity_charge: flat_rate_commodity*usage_ccf
+    flat_rate_commodity: 2.35
+    fixed_drought_surcharge: 0
+    variable_drought_surcharge: 0
+    fixed_wastewater_charge: 0
+    variable_wastewater_charge: 0
+    bill: service_charge+commodity_charge
+  RESIDENTIAL_MULTI:
+    service_charge:
+      depends_on:
+        - meter_size
+      values:
+        5/8": 23.89
+        3/4": 23.89
+        1": 39.78
+        1|1/2": 79.39
+        2": 127.18
+        3": 254.45
+        4": 397.61
+        6": 794.94
+        8": 1272.03
+        10": 1828.43
+        12": 2683.33
+    commodity_charge: flat_rate_commodity*usage_ccf
+    flat_rate_commodity: 2.35
+    fixed_drought_surcharge: 0
+    variable_drought_surcharge: 0
+    fixed_wastewater_charge: 0
+    variable_wastewater_charge: 0
+    bill: service_charge+commodity_charge
+  NON_RESIDENTIAL:
+    service_charge:
+      depends_on:
+        - meter_size
+      values:
+        5/8": 23.89
+        3/4": 23.89
+        1": 39.78
+        1|1/2": 79.39
+        2": 127.18
+        3": 254.45
+        4": 397.61
+        6": 794.94
+        8": 1272.03
+        10": 1828.43
+        12": 2683.33
+    commodity_charge: flat_rate_commodity*usage_ccf
+    flat_rate_commodity: 2.35
+    fixed_drought_surcharge: 0
+    variable_drought_surcharge: 0
+    fixed_wastewater_charge: 0
+    variable_wastewater_charge: 0
+    bill: service_charge+commodity_charge

--- a/full_utility_rates/California/West Sacramento  City Of - 3167/07-01-2020.owrs
+++ b/full_utility_rates/California/West Sacramento  City Of - 3167/07-01-2020.owrs
@@ -1,0 +1,75 @@
+metadata:
+  effective_date: 07/01/2020
+  utility_name: West Sacramento  City Of
+  bill_frequency: Monthly
+  bill_unit: ccf
+rate_structure:
+  RESIDENTIAL_SINGLE:
+    service_charge:
+      depends_on:
+        - meter_size
+      values:
+        5/8": 24.37
+        3/4": 24.37
+        1": 40.58
+        1|1/2": 80.97
+        2": 129.73
+        3": 259.54
+        4": 405.56
+        6": 810.84
+        8": 1297.47
+        10": 1865
+        12": 2737
+    commodity_charge: flat_rate_commodity*usage_ccf
+    flat_rate_commodity: 2.39
+    fixed_drought_surcharge: 0
+    variable_drought_surcharge: 0
+    fixed_wastewater_charge: 0
+    variable_wastewater_charge: 0
+    bill: service_charge+commodity_charge
+  RESIDENTIAL_MULTI:
+    service_charge:
+      depends_on:
+        - meter_size
+      values:
+        5/8": 24.37
+        3/4": 24.37
+        1": 40.58
+        1|1/2": 80.97
+        2": 129.73
+        3": 259.54
+        4": 405.56
+        6": 810.84
+        8": 1297.47
+        10": 1865
+        12": 2737
+    commodity_charge: flat_rate_commodity*usage_ccf
+    flat_rate_commodity: 2.39
+    fixed_drought_surcharge: 0
+    variable_drought_surcharge: 0
+    fixed_wastewater_charge: 0
+    variable_wastewater_charge: 0
+    bill: service_charge+commodity_charge
+  NON_RESIDENTIAL:
+    service_charge:
+      depends_on:
+        - meter_size
+      values:
+        5/8": 24.37
+        3/4": 24.37
+        1": 40.58
+        1|1/2": 80.97
+        2": 129.73
+        3": 259.54
+        4": 405.56
+        6": 810.84
+        8": 1297.47
+        10": 1865
+        12": 2737
+    commodity_charge: flat_rate_commodity*usage_ccf
+    flat_rate_commodity: 2.39
+    fixed_drought_surcharge: 0
+    variable_drought_surcharge: 0
+    fixed_wastewater_charge: 0
+    variable_wastewater_charge: 0
+    bill: service_charge+commodity_charge

--- a/full_utility_rates/California/West Sacramento  City Of - 3167/07-01-2020.owrs
+++ b/full_utility_rates/California/West Sacramento  City Of - 3167/07-01-2020.owrs
@@ -73,3 +73,72 @@ rate_structure:
     fixed_wastewater_charge: 0
     variable_wastewater_charge: 0
     bill: service_charge+commodity_charge
+  IRRIGATION:
+    service_charge:
+      depends_on:
+        - meter_size
+      values:
+        5/8": 24.37
+        3/4": 24.37
+        1": 40.58
+        1|1/2": 80.97
+        2": 129.73
+        3": 259.54
+        4": 405.56
+        6": 810.84
+        8": 1297.47
+        10": 1865
+        12": 2737
+    commodity_charge: flat_rate_commodity*usage_ccf
+    flat_rate_commodity: 2.39
+    fixed_drought_surcharge: 0
+    variable_drought_surcharge: 0
+    fixed_wastewater_charge: 0
+    variable_wastewater_charge: 0
+    bill: service_charge+commodity_charge
+  COMMERCIAL:
+    service_charge:
+      depends_on:
+        - meter_size
+      values:
+        5/8": 24.37
+        3/4": 24.37
+        1": 40.58
+        1|1/2": 80.97
+        2": 129.73
+        3": 259.54
+        4": 405.56
+        6": 810.84
+        8": 1297.47
+        10": 1865
+        12": 2737
+    commodity_charge: flat_rate_commodity*usage_ccf
+    flat_rate_commodity: 2.39
+    fixed_drought_surcharge: 0
+    variable_drought_surcharge: 0
+    fixed_wastewater_charge: 0
+    variable_wastewater_charge: 0
+    bill: service_charge+commodity_charge
+  INDUSTRIAL:
+    service_charge:
+      depends_on:
+        - meter_size
+      values:
+        5/8": 24.37
+        3/4": 24.37
+        1": 40.58
+        1|1/2": 80.97
+        2": 129.73
+        3": 259.54
+        4": 405.56
+        6": 810.84
+        8": 1297.47
+        10": 1865
+        12": 2737
+    commodity_charge: flat_rate_commodity*usage_ccf
+    flat_rate_commodity: 2.39
+    fixed_drought_surcharge: 0
+    variable_drought_surcharge: 0
+    fixed_wastewater_charge: 0
+    variable_wastewater_charge: 0
+    bill: service_charge+commodity_charge

--- a/full_utility_rates/California/West Sacramento  City Of - 3167/07-01-2021.owrs
+++ b/full_utility_rates/California/West Sacramento  City Of - 3167/07-01-2021.owrs
@@ -1,0 +1,75 @@
+metadata:
+  effective_date: 07/01/2021
+  utility_name: West Sacramento  City Of
+  bill_frequency: Monthly
+  bill_unit: ccf
+rate_structure:
+  RESIDENTIAL_SINGLE:
+    service_charge:
+      depends_on:
+        - meter_size
+      values:
+        5/8": 24.61
+        3/4": 24.61
+        1": 40.98
+        1|1/2": 81.78
+        2": 131.02
+        3": 262.13
+        4": 409.61
+        6": 818.94
+        8": 1310.45
+        10": 1883.65
+        12": 2764.37
+    commodity_charge: flat_rate_commodity*usage_ccf
+    flat_rate_commodity: 2.43
+    fixed_drought_surcharge: 0
+    variable_drought_surcharge: 0
+    fixed_wastewater_charge: 0
+    variable_wastewater_charge: 0
+    bill: service_charge+commodity_charge
+  RESIDENTIAL_MULTI:
+    service_charge:
+      depends_on:
+        - meter_size
+      values:
+        5/8": 24.61
+        3/4": 24.61
+        1": 40.98
+        1|1/2": 81.78
+        2": 131.02
+        3": 262.13
+        4": 409.61
+        6": 818.94
+        8": 1310.45
+        10": 1883.65
+        12": 2764.37
+    commodity_charge: flat_rate_commodity*usage_ccf
+    flat_rate_commodity: 2.43
+    fixed_drought_surcharge: 0
+    variable_drought_surcharge: 0
+    fixed_wastewater_charge: 0
+    variable_wastewater_charge: 0
+    bill: service_charge+commodity_charge
+  NON_RESIDENTIAL:
+    service_charge:
+      depends_on:
+        - meter_size
+      values:
+        5/8": 24.61
+        3/4": 24.61
+        1": 40.98
+        1|1/2": 81.78
+        2": 131.02
+        3": 262.13
+        4": 409.61
+        6": 818.94
+        8": 1310.45
+        10": 1883.65
+        12": 2764.37
+    commodity_charge: flat_rate_commodity*usage_ccf
+    flat_rate_commodity: 2.43
+    fixed_drought_surcharge: 0
+    variable_drought_surcharge: 0
+    fixed_wastewater_charge: 0
+    variable_wastewater_charge: 0
+    bill: service_charge+commodity_charge

--- a/full_utility_rates/California/West Sacramento  City Of - 3167/07-01-2021.owrs
+++ b/full_utility_rates/California/West Sacramento  City Of - 3167/07-01-2021.owrs
@@ -73,3 +73,72 @@ rate_structure:
     fixed_wastewater_charge: 0
     variable_wastewater_charge: 0
     bill: service_charge+commodity_charge
+  IRRIGATION:
+    service_charge:
+      depends_on:
+        - meter_size
+      values:
+        5/8": 24.61
+        3/4": 24.61
+        1": 40.98
+        1|1/2": 81.78
+        2": 131.02
+        3": 262.13
+        4": 409.61
+        6": 818.94
+        8": 1310.45
+        10": 1883.65
+        12": 2764.37
+    commodity_charge: flat_rate_commodity*usage_ccf
+    flat_rate_commodity: 2.43
+    fixed_drought_surcharge: 0
+    variable_drought_surcharge: 0
+    fixed_wastewater_charge: 0
+    variable_wastewater_charge: 0
+    bill: service_charge+commodity_charge
+  COMMERCIAL:
+    service_charge:
+      depends_on:
+        - meter_size
+      values:
+        5/8": 24.61
+        3/4": 24.61
+        1": 40.98
+        1|1/2": 81.78
+        2": 131.02
+        3": 262.13
+        4": 409.61
+        6": 818.94
+        8": 1310.45
+        10": 1883.65
+        12": 2764.37
+    commodity_charge: flat_rate_commodity*usage_ccf
+    flat_rate_commodity: 2.43
+    fixed_drought_surcharge: 0
+    variable_drought_surcharge: 0
+    fixed_wastewater_charge: 0
+    variable_wastewater_charge: 0
+    bill: service_charge+commodity_charge
+  INDUSTRIAL:
+    service_charge:
+      depends_on:
+        - meter_size
+      values:
+        5/8": 24.61
+        3/4": 24.61
+        1": 40.98
+        1|1/2": 81.78
+        2": 131.02
+        3": 262.13
+        4": 409.61
+        6": 818.94
+        8": 1310.45
+        10": 1883.65
+        12": 2764.37
+    commodity_charge: flat_rate_commodity*usage_ccf
+    flat_rate_commodity: 2.43
+    fixed_drought_surcharge: 0
+    variable_drought_surcharge: 0
+    fixed_wastewater_charge: 0
+    variable_wastewater_charge: 0
+    bill: service_charge+commodity_charge


### PR DESCRIPTION
Included residential and non-residential rates for 2017 to 2021.
Flat rates (unmetered units) not included yet.