### PR TITLE
Adding Modesto  City Of OWRS file for 09-01-2016

### DIFF
--- a/full_utility_rates/California/Modesto  City Of - 1857/09-01-2016.owrs
+++ b/full_utility_rates/California/Modesto  City Of - 1857/09-01-2016.owrs
@@ -1,0 +1,97 @@
+metadata:
+  effective_date: 09/01/2016
+  utility_name: Modesto  City Of
+  bill_frequency: Monthly
+  bill_unit: ccf
+rate_structure:
+  RESIDENTIAL_SINGLE:
+    service_charge:
+      depends_on:
+        - meter_size
+      values:
+        5/8": 20.79
+        3/4": 20.79
+        1": 29.3
+        1|1/2": 50.58
+        2": 76.11
+        3": 156.98
+        4": 276.14
+        6": 561.28
+        8": 1029.42
+        10": 1625.23
+        12": 2135.93
+    commodity_charge: flat_rate_commodity*usage_ccf
+    flat_rate_commodity: 1.79
+    fixed_drought_surcharge: 0
+    variable_drought_surcharge: 0
+    fixed_wastewater_charge: 0
+    variable_wastewater_charge: 0
+    bill: service_charge+commodity_charge
+  RESIDENTIAL_MULTI:
+    service_charge:
+      depends_on:
+        - meter_size
+      values:
+        5/8": 20.79
+        3/4": 20.79
+        1": 29.3
+        1|1/2": 50.58
+        2": 76.11
+        3": 156.98
+        4": 276.14
+        6": 561.28
+        8": 1029.42
+        10": 1625.23
+        12": 2135.93
+    commodity_charge: flat_rate_commodity*usage_ccf
+    flat_rate_commodity: 1.79
+    fixed_drought_surcharge: 0
+    variable_drought_surcharge: 0
+    fixed_wastewater_charge: 0
+    variable_wastewater_charge: 0
+    bill: service_charge+commodity_charge
+  NON_RESIDENTIAL:
+    service_charge:
+      depends_on:
+        - meter_size
+      values:
+        5/8": 20.79
+        3/4": 20.79
+        1": 29.3
+        1|1/2": 50.58
+        2": 76.11
+        3": 156.98
+        4": 276.14
+        6": 561.28
+        8": 1029.42
+        10": 1625.23
+        12": 2135.93
+    commodity_charge: flat_rate_commodity*usage_ccf
+    flat_rate_commodity: 1.79
+    fixed_drought_surcharge: 0
+    variable_drought_surcharge: 0
+    fixed_wastewater_charge: 0
+    variable_wastewater_charge: 0
+    bill: service_charge+commodity_charge
+  UNMETERED:
+    service_charge:
+      depends_on:
+        - meter_size
+      values:
+        5/8": 20.79
+        3/4": 20.79
+        1": 29.3
+        1|1/2": 50.58
+        2": 76.11
+        3": 156.98
+        4": 276.14
+        6": 561.28
+        8": 1029.42
+        10": 1625.23
+        12": 2135.93
+    commodity_charge: 0
+    fixed_drought_surcharge: 0
+    variable_drought_surcharge: 0
+    fixed_wastewater_charge: 0
+    variable_wastewater_charge: 0
+    bill: service_charge+commodity_charge

--- a/full_utility_rates/California/Modesto  City Of - 1857/09-01-2016.owrs
+++ b/full_utility_rates/California/Modesto  City Of - 1857/09-01-2016.owrs
@@ -73,6 +73,75 @@ rate_structure:
     fixed_wastewater_charge: 0
     variable_wastewater_charge: 0
     bill: service_charge+commodity_charge
+  IRRIGATION:
+    service_charge:
+      depends_on:
+        - meter_size
+      values:
+        5/8": 20.79
+        3/4": 20.79
+        1": 29.3
+        1|1/2": 50.58
+        2": 76.11
+        3": 156.98
+        4": 276.14
+        6": 561.28
+        8": 1029.42
+        10": 1625.23
+        12": 2135.93
+    commodity_charge: flat_rate_commodity*usage_ccf
+    flat_rate_commodity: 1.79
+    fixed_drought_surcharge: 0
+    variable_drought_surcharge: 0
+    fixed_wastewater_charge: 0
+    variable_wastewater_charge: 0
+    bill: service_charge+commodity_charge
+  COMMERCIAL:
+    service_charge:
+      depends_on:
+        - meter_size
+      values:
+        5/8": 20.79
+        3/4": 20.79
+        1": 29.3
+        1|1/2": 50.58
+        2": 76.11
+        3": 156.98
+        4": 276.14
+        6": 561.28
+        8": 1029.42
+        10": 1625.23
+        12": 2135.93
+    commodity_charge: flat_rate_commodity*usage_ccf
+    flat_rate_commodity: 1.79
+    fixed_drought_surcharge: 0
+    variable_drought_surcharge: 0
+    fixed_wastewater_charge: 0
+    variable_wastewater_charge: 0
+    bill: service_charge+commodity_charge
+  INDUSTRIAL:
+    service_charge:
+      depends_on:
+        - meter_size
+      values:
+        5/8": 20.79
+        3/4": 20.79
+        1": 29.3
+        1|1/2": 50.58
+        2": 76.11
+        3": 156.98
+        4": 276.14
+        6": 561.28
+        8": 1029.42
+        10": 1625.23
+        12": 2135.93
+    commodity_charge: flat_rate_commodity*usage_ccf
+    flat_rate_commodity: 1.79
+    fixed_drought_surcharge: 0
+    variable_drought_surcharge: 0
+    fixed_wastewater_charge: 0
+    variable_wastewater_charge: 0
+    bill: service_charge+commodity_charge
   UNMETERED:
     service_charge:
       depends_on:


### PR DESCRIPTION
Unmetered rates include tax. The pure water rate is a little lower. 
They mention:
"Drought water rates shall be imposed when the State Water Resources Control Board imposes a mandatory conservation target that exceeds the City’s self-imposed conservation target."
but don't specify how much the drought rates would be.